### PR TITLE
Added the 'Usage on Windows' section to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Copy the three Python files to `~/.gdb/qt5printers/` and add this to your
 Now verify it with your favorite program. Below you can find a quick test
 program.
 
+### Usage on Windows
+To make it work, consider using the `C:\Users\<your_user_name>` folder as `~/`. Also, create an environment variable `HOME`, pointing to `C:\Users\<your_user_name>`.
+
 ### Test program
 Here is a test program (save it as `test.cpp`):
 


### PR DESCRIPTION
As there is no default `~/` path on Windows, the stuff here doesn't work out of the box and requires some additional actions. 

The PR adds an instruction of how to make it work on Windows.

Based on [this](https://stackoverflow.com/questions/51324228/where-to-put-gdbinit-in-windows) and [this](https://stackoverflow.com/questions/15399265/how-do-i-load-gdbinit-on-gdb-startup) Stack Overflow questions.