### PR TITLE
Added necessary -fPIC flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Here is a test program (save it as `test.cpp`):
 
 Compile it with:
 
-    g++ test.cpp $(pkg-config --cflags --libs Qt5Core) -g
+    g++ test.cpp $(pkg-config --cflags --libs Qt5Core) -g -fPIC
 
 If everything goes well you should see the expanded data:
 


### PR DESCRIPTION
```
vadi@gooseberry:~$ nano test.cpp
vadi@gooseberry:~$ g++ test.cpp $(pkg-config --cflags --libs Qt5Core) -g
In file included from /usr/include/x86_64-linux-gnu/qt5/QtCore/qiodevice.h:43,
                 from /usr/include/x86_64-linux-gnu/qt5/QtCore/qtextstream.h:43,
                 from /usr/include/x86_64-linux-gnu/qt5/QtCore/QTextStream:1,
                 from test.cpp:1:
/usr/include/x86_64-linux-gnu/qt5/QtCore/qglobal.h:1187:4: error: #error "You must build your code with position independent code if Qt was built with -reduce-relocations. " "Compile your code with -fPIC (-fPIE is not enough)."
 #  error "You must build your code with position independent code if Qt was built with -reduce-relocations. "\
    ^~~~~
vadi@gooseberry:~$ g++ test.cpp $(pkg-config --cflags --libs Qt5Core) -g -fPIC
vadi@gooseberry:~$ 
```

Thanks a lot for including an easy to test example! It really makes a difference.